### PR TITLE
Dependency kappy<4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     license="MIT",
     keywords="simulation biology modeling complex kappa binding",
     packages=find_packages(exclude="docs"),
-    install_requires=["kappy", "networkx", "matplotlib", "numpy", "termcolor"],
+    install_requires=["kappy<4.1", "networkx", "matplotlib", "numpy", "termcolor"],
 )


### PR DESCRIPTION
kappy v4.1 has changed the API, which requires a rewrite of topkappy
functions. Dependency pinned while updating topkappy in the kappy_v4.1
branch.